### PR TITLE
Add deployment guide using Ansible and Helm

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,59 @@
+# Deployment Guide: Using Ansible, Jenkins, Helm, Git & Kubernetes
+
+This guide provides a high-level workflow for deploying a Java Spring Boot application with
+Ansible automation, Helm charts, Jenkins pipelines, Git (with GitHub), and Kubernetes. Use
+these instructions as a template and adapt them to your infrastructure and naming.
+
+## 1. Source Control with Git/GitHub
+
+1. Initialize a Git repository for your Spring Boot project.
+2. Push the repository to GitHub for centralized version control.
+3. Protect your `main` (or `master`) branch and enforce pull requests.
+
+## 2. Continuous Integration with Jenkins
+
+1. Create a Jenkins pipeline (declarative or scripted) in a `Jenkinsfile` stored in the repo.
+2. The pipeline should:
+   - Checkout code from GitHub.
+   - Run unit tests and integration tests.
+   - Build the application with Maven or Gradle.
+   - Build a Docker image and push it to a registry (e.g., Docker Hub).
+3. Configure webhooks in GitHub so that Jenkins builds on each pull request or commit.
+
+## 3. Packaging with Helm
+
+1. Create a Helm chart (`charts/<chart-name>`) describing your Kubernetes resources
+   (Deployment, Service, Ingress, etc.).
+2. Template out values like image tag, replica count, and environment variables.
+3. Test the chart locally using `helm template` and `helm lint`.
+4. Store the chart in the same Git repository or in a dedicated Helm chart repo.
+
+## 4. Infrastructure Automation with Ansible
+
+1. Write an Ansible playbook to install and configure Kubernetes clusters (if needed)
+   or manage cluster resources.
+2. Use Ansible tasks to:
+   - Install required packages (kubectl, helm, Docker).
+   - Authenticate with the container registry.
+   - Deploy the Helm chart to your Kubernetes cluster using `helm upgrade --install`.
+3. Parameterize the playbook with variables for environment (staging, production, etc.).
+
+## 5. Kubernetes Deployment
+
+1. Ensure your cluster (e.g., Minikube, AKS, EKS, GKE) is running and accessible.
+2. Jenkins can trigger Ansible to deploy the new Docker image via Helm.
+3. Monitor the rollout using `kubectl rollout status deployment/<name>`.
+4. Expose your service using a LoadBalancer or Ingress and verify connectivity.
+
+## 6. Putting It All Together
+
+A typical flow is:
+1. Developer pushes code to GitHub.
+2. GitHub notifies Jenkins via webhook.
+3. Jenkins builds, tests, and pushes a Docker image.
+4. Jenkins triggers an Ansible playbook.
+5. Ansible authenticates to the Kubernetes cluster and deploys the updated image via Helm.
+6. The application is updated in Kubernetes with zero downtime (if configured).
+
+This combination of tools enables a robust CI/CD pipeline with infrastructure-as-code
+and reliable, repeatable deployments.


### PR DESCRIPTION
## Summary
- add DEPLOYMENT_GUIDE explaining CI/CD workflow using GitHub, Jenkins, Ansible, Helm, and Kubernetes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857fb4d3b8c8321a9262c94794da276