### PR TITLE
Add Ansible playbooks for CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,21 @@ Next Steps
     Consider adding instructions on how to run your Python automation scripts once the backend is in place.
 
 This workflow establishes a standard approach for delivering REST APIs with Java Spring Boot, storing data in MySQL, and automating deployment tasks with Python.
+
+## Ansible CI/CD Playbooks
+
+The `ansible` directory contains example playbooks used to provision a CI/CD
+pipeline. These playbooks install Docker, Jenkins, kubectl and Helm on a target
+host and deploy the application using Helm charts.
+
+### Running the Playbooks
+
+1. Edit `ansible/inventory/hosts.yml` and update the `cicd` host details.
+2. Run the site playbook:
+
+```bash
+ansible-playbook -i ansible/inventory/hosts.yml ansible/site.yml
+```
+
+Variables for the deployment role (repository URL, chart path, etc.) can be
+customized in `ansible/roles/deployer/defaults/main.yml`.

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    cicd:
+      ansible_host: 192.168.1.100
+      ansible_user: ubuntu

--- a/ansible/roles/deployer/defaults/main.yml
+++ b/ansible/roles/deployer/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+repo_url: https://github.com/example/JavaSpringBoot.git
+deploy_dir: /opt/app
+release_name: java-springboot
+chart_path: helm/java-springboot
+image_tag: latest

--- a/ansible/roles/deployer/tasks/main.yml
+++ b/ansible/roles/deployer/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Checkout application repository
+  git:
+    repo: "{{ repo_url }}"
+    dest: "{{ deploy_dir }}"
+    version: "{{ repo_version | default('main') }}"
+
+- name: Deploy application with Helm
+  command: >
+    helm upgrade --install {{ release_name }} {{ chart_path }}
+    --set image.tag={{ image_tag }}
+  args:
+    chdir: "{{ deploy_dir }}"

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Install Docker
+  apt:
+    name: docker.io
+    state: present
+
+- name: Ensure Docker service is running
+  service:
+    name: docker
+    state: started
+    enabled: yes

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install Java
+  apt:
+    name: openjdk-11-jdk
+    state: present
+
+- name: Add Jenkins apt key
+  apt_key:
+    url: https://pkg.jenkins.io/debian-stable/jenkins.io.key
+    state: present
+
+- name: Add Jenkins repository
+  apt_repository:
+    repo: deb https://pkg.jenkins.io/debian-stable binary/
+    state: present
+
+- name: Install Jenkins
+  apt:
+    name: jenkins
+    state: present
+
+- name: Ensure Jenkins is running
+  service:
+    name: jenkins
+    state: started
+    enabled: yes

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Install kubectl
+  apt:
+    name: kubectl
+    state: present
+
+- name: Install Helm
+  snap:
+    name: helm
+    classic: yes

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,7 @@
+- hosts: cicd
+  become: yes
+  roles:
+    - docker
+    - jenkins
+    - kubernetes
+    - deployer


### PR DESCRIPTION
## Summary
- document Ansible playbooks in README
- add Ansible inventory and site playbook
- add roles for Docker, Jenkins, Kubernetes tools and deployment

## Testing
- `ansible-playbook --syntax-check ansible/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580064c0488321b6ee753882057f7f